### PR TITLE
Remove version from .info file.

### DIFF
--- a/navbar.info
+++ b/navbar.info
@@ -8,4 +8,3 @@ tags[] = Structure
 tags[] = Administration
 type = module
 dependencies[] = libraries
-version = "1.x-1.7.0"


### PR DESCRIPTION
This will be added automatically by the packaging script when you move the project to backdrop-contrib and create a release via GitHub.